### PR TITLE
Clean after tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -6,7 +6,9 @@ from elasticsearch import Elasticsearch
 def es(host="127.0.0.1"):
     e = Elasticsearch(hosts=[host])
     ic = e.indices
-    ic.create('xpd')
-    ic.create('iss')
-    ic.create('bad_xpd')
-    return e
+    ic.create('dbes-test-xpd')
+    ic.create('dbes-test-iss')
+    ic.create('dbes-test-bad_xpd')
+    yield e
+    ic.delete('dbes-test-*')
+    return

--- a/src/tests/test_callback.py
+++ b/src/tests/test_callback.py
@@ -53,7 +53,7 @@ def xpd_filter(x):
 @pytest.mark.parametrize(
     "idx, dm, bl, f, doc",
     zip(
-        ["xpd", "iss"],
+        ["dbes-test-xpd", "dbes-test-iss"],
         [
             [("uid", "uid", noconversion), ("bl", "bl", noconversion)],
             [("uid", "uid", noconversion), ("bl", "bl", noconversion)],
@@ -74,7 +74,7 @@ def test_callback(es, idx, dm, bl, f, doc):
 def test_no_op_callback(es):
     cb = ElasticInsert(
         es=es,
-        esindex="bad_xpd",
+        esindex="dbes-test-bad_xpd",
         docmap=[("uid", "uid", noconversion), ("bl", "bl", noconversion)],
         beamline="xpd",
         criteria=xpd_filter,

--- a/src/tests/test_callback.py
+++ b/src/tests/test_callback.py
@@ -68,7 +68,7 @@ def test_callback(es, idx, dm, bl, f, doc):
     cb("start", doc)
     es.indices.flush()
     res = es.search(idx, body={"query": {"match_all": {}}})
-    assert len(res["hits"]["hits"]) == 1
+    assert res["hits"]["total"] == 1
 
 
 def test_no_op_callback(es):
@@ -82,4 +82,4 @@ def test_no_op_callback(es):
     cb("start", xpd_bad_doc)
     es.indices.flush()
     res = es.search("bad_xpd", body={"query": {"match_all": {}}})
-    assert len(res["hits"]["hits"]) == 0
+    assert res["hits"]["total"] == 0

--- a/src/tests/test_callback.py
+++ b/src/tests/test_callback.py
@@ -81,5 +81,5 @@ def test_no_op_callback(es):
     )
     cb("start", xpd_bad_doc)
     es.indices.flush()
-    res = es.search("bad_xpd", body={"query": {"match_all": {}}})
+    res = es.search("dbes-test-bad_xpd", body={"query": {"match_all": {}}})
     assert res["hits"]["total"] == 0


### PR DESCRIPTION
- rename temporary test indices so they don't clash with production ones.
- delete temporary indices after test.

Resolve #5.
